### PR TITLE
Modified some endpoints from the user point of view

### DIFF
--- a/openapi-definitions.yaml
+++ b/openapi-definitions.yaml
@@ -123,14 +123,3 @@ FullfilledSignatureRequest:
           type: array
           items:
             $ref: "#/components/schemas/Document"
-fiscalCode:
-  name: fiscal_code
-  in: path
-  type: string
-  maxlength: 16
-  minlength: 16
-  required: true
-  description: the fiscal code of the user. All upper case
-  pattern: >-
-    [A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]
-  X-example: ABCDEF99S01A555Z

--- a/openapi-definitions.yaml
+++ b/openapi-definitions.yaml
@@ -123,3 +123,14 @@ FullfilledSignatureRequest:
           type: array
           items:
             $ref: "#/components/schemas/Document"
+fiscalCode:
+  name: fiscal_code
+  in: path
+  type: string
+  maxlength: 16
+  minlength: 16
+  required: true
+  description: the fiscal code of the user. All upper case
+  pattern: >-
+    [A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]
+  X-example: ABCDEF99S01A555Z

--- a/openapi-user.yaml
+++ b/openapi-user.yaml
@@ -6,15 +6,9 @@ info:
   version: 1.0.0
 
 paths:
-  /signer/{id}:
+  /signer/{fiscalCode}:
     parameters:
-      - name: id
-        in: path
-        description: Signer Id
-        required: true
-        schema:
-          type: string
-          format: uuid
+      $ref: "#/components/schemas/FiscalCode"
     get:
       operationId: GetSigner
       tags:
@@ -84,25 +78,16 @@ paths:
       operationId: GetQTSPClauses
       tags:
         - QTSP
-      parameters:
-        - name: qtsp
-          in: query
-          required: true
-          schema:
-            type: string
-            enum: ["qtsp1", "qtsp2"]
       responses:
         200:
           description: QTSP terms and conditions
           content:
             application/json:
               schema:
+                name: QtspClauses
                 type: array
                 items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
+                  $ref: "#/components/schemas/QtspClause"
     patch:
       operationId: EditQstpClauses
       tags:
@@ -168,3 +153,24 @@ paths:
 components:
   schemas:
     $ref: "./openapi-definitions.yaml"
+    QtspClause:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        qtspId:
+          type: string
+          format: uuid
+        title:
+          type: string
+          required: true
+        text:
+          type: string
+          required: false
+        mandatory:
+          type: boolean
+          required: true
+        signed:
+          type: boolean
+          required: true

--- a/openapi-user.yaml
+++ b/openapi-user.yaml
@@ -6,9 +6,15 @@ info:
   version: 1.0.0
 
 paths:
-  /signer/{fiscalCode}:
+  /signer/{id}:
     parameters:
-      $ref: "#/components/schemas/FiscalCode"
+      - name: id
+        in: path
+        description: Signature Request Id
+        required: true
+        schema:
+          type: string
+          format: uuid
     get:
       operationId: GetSigner
       tags:


### PR DESCRIPTION
In this first commit I changed the endpoints:
- /signer to manage the parameter that the app will send that should be the fiscal code of the user;
- the qtsp-clauses to manage a proposed structure for the clauses that the app will receive during the onboarding.

For the first call I create a component into openapi-definition.yaml to describe how should be the fiscal code, for the second I created, into the openapi-user.yaml, the component qtsp-clause to manage the single clause.
Tell me if you agree with these changes @gunzip , @lucacavallaro , @hevelius  and @grausof 