### PR TITLE
Add signature field ID to DOCUMENT clause [SFEQS-994]

### DIFF
--- a/openapi-issuer.yaml
+++ b/openapi-issuer.yaml
@@ -271,10 +271,13 @@ components:
       properties:
         title:
           type: string
+        signatureFieldId:
+          type: string
         required:
           type: boolean
       required:
         - title
+        - signatureFieldId
         - required
     DocumentMetadata:
       type: object

--- a/src/app/use-cases/__test__/mock.ts
+++ b/src/app/use-cases/__test__/mock.ts
@@ -32,6 +32,7 @@ export const mockGetProduct: GetProduct = (
           clauses: [
             {
               title: "doc-tos",
+              signatureFieldId: "sign1",
               required: false,
             },
           ],
@@ -58,6 +59,7 @@ export const mockGetSignatureRequest: GetSignatureRequest = (
           clauses: [
             {
               title: "doc-tos",
+              signatureFieldId: "sign1",
               required: false,
             },
           ],

--- a/src/signature-request/__test__/clause.spec.ts
+++ b/src/signature-request/__test__/clause.spec.ts
@@ -19,6 +19,7 @@ describe("ClauseList", () => {
       list: [
         {
           title: "Clause 1",
+          signatureFieldId: "sign1",
           required: false,
         },
       ],

--- a/src/signature-request/__test__/document.spec.ts
+++ b/src/signature-request/__test__/document.spec.ts
@@ -24,6 +24,7 @@ describe("DocumentList", () => {
           clauses: [
             {
               title: "Clause 1",
+              signatureFieldId: "sign1",
               required: false,
             },
           ],

--- a/src/signature-request/__test__/signature-request.spec.ts
+++ b/src/signature-request/__test__/signature-request.spec.ts
@@ -20,6 +20,7 @@ describe("SignatureRequestList", () => {
             clauses: [
               {
                 title: "Clause 1",
+                signatureFieldId: "sign1",
                 required: false,
               },
             ],

--- a/src/signature-request/clause.ts
+++ b/src/signature-request/clause.ts
@@ -2,10 +2,12 @@ import * as t from "io-ts";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 export const ClauseTitle = NonEmptyString;
+export const SignatureFieldId = NonEmptyString;
 
 export const Clause = t.type({
   title: ClauseTitle,
   required: t.boolean,
+  signatureFieldId: SignatureFieldId,
 });
 
 export type Clause = t.TypeOf<typeof Clause>;


### PR DESCRIPTION
As an ISSUER, I need to be able to indicate the ID of the signature field within the DOCUMENT associated with the clause.

#### Types of changes
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
