### PR TITLE
Add user OpenApi [SFEQS-726]

### DIFF
--- a/docs/openapi-user.yaml
+++ b/docs/openapi-user.yaml
@@ -311,6 +311,14 @@ components:
       format: base64url
       description: SPID SAML assertion encoded in base64
 
+    ClausesSignature:
+      type: object
+      properties:
+        signatureFieldId:
+          type: string
+        accepted:
+          type: boolean
+
     DocumentSignature:
       type: object
       properties:
@@ -321,9 +329,14 @@ components:
           type: string
           format: base64url
           description: Signature of document digest concatenated with document clauses
+        clauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/ClausesSignature"
       required:
         - documentId
         - signature
+        - clauses
 
     QtspClausesMetadata:
       type: object

--- a/docs/openapi-user.yaml
+++ b/docs/openapi-user.yaml
@@ -1,170 +1,406 @@
 openapi: 3.0.3
-
 info:
-  title: Firma con IO User APIs
-  description: Any APIs called by IO App
-  version: 1.0.0
-
+  title: IO Sign - User API
+  version: 0.0.1
 paths:
-  /signer/{id}:
-    parameters:
-      - name: id
-        in: path
-        description: Signer Id
-        required: true
-        schema:
-          type: string
-          format: uuid
+  /signature-requests/{signatureRequestId}:
     get:
-      operationId: GetSigner
-      tags:
-        - Signer
-      responses:
-        200:
-          description: signer profile
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Signer"
-        404:
-          description: signer not found
-    patch:
-      operationId: EditSigner
-      tags:
-        - Signer
-      responses:
-        200:
-          description: successful operation
-        404:
-          description: signer not found
-
-  /signature-requests{id}:
-    parameters:
-      - name: id
-        in: path
-        description: Signature Request Id
-        required: true
-        schema:
-          type: string
-          format: uuid
-    get:
-      operationId: getSignatureRequest
-      tags:
-        - Signature Request
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: "#/components/schemas/DraftSignatureRequest"
-                  - $ref: "#/components/schemas/SignatureRequest"
-                  - $ref: "#/components/schemas/FullfilledSignatureRequest"
-                discriminator:
-                  propertyName: status
-                  mapping:
-                    draft: "#/components/schemas/DraftSignatureRequest"
-                    forwarded: "#/components/schemas/SignatureRequest"
-                    fullfilled: "#/components/schemas/FullfilledSignatureRequest"
-        404:
-          description: signature request not found
-    patch:
-      operationId: EditSignatureRequest
-      tags:
-        - Signature Request
-      responses:
-        200:
-          description: successful operation
-        404:
-          description: signature request not found
-
-  /qtsp-clauses:
-    get:
-      operationId: GetQTSPClauses
-      tags:
-        - QTSP
+      operationId: getSignatureRequestById
+      summary: Get a Signature Request By Id
       parameters:
-        - name: qtsp
-          in: query
-          required: true
+        - in: path
+          name: signatureRequestId
           schema:
-            type: string
-            enum: ["qtsp1", "qtsp2"]
+            $ref: "#/components/schemas/SignatureRequestId"
+          required: true
       responses:
-        200:
-          description: QTSP terms and conditions
+        "200":
+          description: The Signature Request detail
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-    patch:
-      operationId: EditQstpClauses
-      tags:
-        - QTSP
+                $ref: "#/components/schemas/SignatureRequestDetailView"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Unexpected"
+
+  /qtsp/clauses:
+    get:
+      operationId: getQtspClauses
+      summary: Get clauses list and MRC from QTSP
       responses:
-        200:
-          description: successful operation
-        404:
-          description: QTSP clauses not found
+        "200":
+          description: The QTSP clauses list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QtspClauses"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Unexpected"
+  /signatures/{signatureId}:
+    get:
+      operationId: getSignatureById
+      summary: Get a Signature By Id
+      parameters:
+        - in: path
+          name: signatureId
+          schema:
+            $ref: "#/components/schemas/SignatureId"
+          required: true
+      responses:
+        "200":
+          description: The Signature Request detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignatureDetailView"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Unexpected"
 
   /signatures:
     post:
-      operationId: Sign
-      tags:
-        - QTSP
+      operationId: createSignature
+      summary: Create a Signature from SignatureRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSignatureBody"
       responses:
-        201:
-          description: successful operation
+        "201":
+          description: Signature created
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-
-  /sessions:
-    post:
-      operationId: CreateSession
-      tags:
-        - QTSP
-      responses:
-        201:
-          description: successful operation
-
-  /sessions/{id}:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-    get:
-      operationId: GetSession
-      tags:
-        - QTSP
-      responses:
-        200:
-          description: the session
-        404:
-          description: session not found
-    patch:
-      operationId: EditSession
-      tags:
-        - QTSP
-      responses:
-        200:
-          description: successful operation
-        404:
-          description: session not found
+                $ref: "#/components/schemas/SignatureDetailView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        default:
+          $ref: "#/components/responses/Unexpected"
 
 components:
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemJson"
+    BadRequest:
+      description: Validation error on body
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemJson"
+    Forbidden:
+      description: You don't have enough privileges to perform this action
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemJson"
+    Unexpected:
+      description: Unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemJson"
   schemas:
-    $ref: "./openapi-definitions.yaml"
+    ProblemJson:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+          description: |-
+            An absolute URI that identifies the problem type. When dereferenced,
+            it SHOULD provide human-readable documentation for the problem type
+            (e.g., using HTML).
+          default: about:blank
+          example: https://example.com/problem/constraint-violation
+        title:
+          type: string
+          description: >-
+            A short, summary of the problem type. Written in english and
+            readable
+
+            for engineers (usually not suited for non technical stakeholders and
+
+            not localized); example: Service Unavailable
+        status:
+          type: integer
+          format: int32
+          description: >-
+            The HTTP status code generated by the origin server for this
+            occurrence of the problem.
+          minimum: 100
+          maximum: 600
+          exclusiveMaximum: true
+          example: 200
+        detail:
+          type: string
+          description: |-
+            A human readable explanation specific to this occurrence of the
+            problem.
+          example: There was an error processing the request
+        instance:
+          type: string
+          format: uri
+          description: >-
+            An absolute URI that identifies the specific occurrence of the
+            problem. It may or may not yield further information if
+            dereferenced.
+      required:
+        - title
+        - status
+        - detail
+    Email:
+      type: string
+      description: User's email.
+      format: EmailString
+      x-import: "@pagopa/ts-commons/lib/strings"
+      example: me@example.com
+    Clause:
+      type: object
+      properties:
+        title:
+          type: string
+        signatureFieldId:
+          type: string
+        required:
+          type: boolean
+      required:
+        - title
+        - signatureFieldId
+        - required
+    DocumentMetadata:
+      type: object
+      properties:
+        title:
+          type: string
+        clauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/Clause"
+          minItems: 1
+          uniqueItems: true
+      required:
+        - title
+        - clauses
+    Document:
+      allOf:
+        - type: object
+          properties:
+            id:
+              type: string
+              format: ulid
+            url:
+              type: string
+              format: uri
+          required:
+            - id
+        - $ref: "#/components/schemas/DocumentMetadata"
+    ProductId:
+      type: string
+      format: ulid
+    Timestamp:
+      type: string
+      format: UTCISODateFromString
+      description: A date-time field in ISO-8601 format and UTC timezone.
+      x-import: "@pagopa/ts-commons/lib/dates"
+      example: "2018-10-13T00:00:00.000Z"
+    QrCodeUrl:
+      type: string
+      format: url
+      minLength: 1
+
+    SignatureRequestStatus:
+      type: string
+      x-extensible-enum:
+        - DRAFT
+        - WAIT_FOR_ISSUER
+        - READY
+        - WAIT_FOR_SIGNATURE
+        - SIGNED
+      description: >
+        Signature request status:
+         * `DRAFT` - The signature request has been created but not all documents have been uploaded yet.
+         * `WAIT_FOR_ISSUER` - All documents have been uploaded but the ISSUER has not yet marked the signature request as READY.
+         * `READY` - The signature request is ready for processing. In this phase the documents will be analyzed and prepared for sending to the USER.
+         * `WAIT_FOR_SIGNATURE` - The signature request has been sent to the user and is awaiting signature
+         * `SIGNED` - The signature request was successfully signed.
+
+    SignatureRequestDetailView:
+      type: object
+      properties:
+        id:
+          type: string
+          format: ulid
+        status:
+          $ref: "#/components/schemas/SignatureRequestStatus"
+        productId:
+          $ref: "#/components/schemas/ProductId"
+        expiresAt:
+          $ref: "#/components/schemas/Timestamp"
+        qrCodeUrl:
+          $ref: "#/components/schemas/QrCodeUrl"
+        documents:
+          type: array
+          items:
+            $ref: "#/components/schemas/Document"
+      required:
+        - id
+        - productId
+        - qrCodeUrl
+        - documents
+    SignatureRequestId:
+      type: string
+      format: ulid
+      minLength: 1
+
+    QtspClauses:
+      type: object
+      properties:
+        clauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/QtspClause"
+          minItems: 1
+          uniqueItems: true
+        mrcDocumentUrl:
+          type: string
+          format: uri
+        privacyDocumentUrl:
+          type: string
+          format: uri
+        tosDocumentUrl:
+          type: string
+          format: uri
+      required:
+        - text
+        - mrcUrl
+
+    QtspClause:
+      type: object
+      properties:
+        text:
+          type: string
+      required:
+        - text
+
+    PublicKey:
+      type: string
+      format: base64url
+      description: PEM public key encoded in base64
+
+    SamlAssertion:
+      type: string
+      format: base64url
+      description: SPID SAML assertion encoded in base64
+
+    DocumentSignature:
+      type: object
+      properties:
+        documentId:
+          type: string
+          format: ulid
+        signature:
+          type: string
+          format: base64url
+          description: Signature of document digest concatenated with document clauses
+      required:
+        - documentId
+        - signature
+
+    QtspClausesMetadata:
+      type: object
+      properties:
+        acceptedClauses:
+          type: array
+          items:
+            $ref: "#/components/schemas/QtspClause"
+          minItems: 1
+          uniqueItems: true
+        mrcDocumentUrl:
+          type: string
+          format: uri
+        signature:
+          type: string
+          format: base64url
+          description: Signature of MRC digest concatenated with QTSP accepted clauses
+      required:
+        - qtspAcceptedClauses
+        - signature
+
+    CreateSignatureBody:
+      type: object
+      properties:
+        signatureRequestId:
+          $ref: "#/components/schemas/SignatureRequestId"
+        email:
+          $ref: "#/components/schemas/Email"
+        publicKey:
+          $ref: "#/components/schemas/PublicKey"
+        spidSamlAssertion:
+          $ref: "#/components/schemas/SamlAssertion"
+        documentSignatures:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentSignature"
+          minItems: 1
+          uniqueItems: true
+        qtspClauses:
+          $ref: "#/components/schemas/QtspClausesMetadata"
+      required:
+        - signatureRequestId
+        - email
+        - publicKey
+        - spidSamlAssertion
+        - documentSignatures
+        - qtspClauses
+
+    SignatureId:
+      type: string
+      format: ulid
+      minLength: 1
+
+    SignatureDetailView:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/SignatureId"
+        signatureRequestId:
+          $ref: "#/components/schemas/SignatureRequestId"
+        email:
+          $ref: "#/components/schemas/Email"
+        publicKey:
+          $ref: "#/components/schemas/PublicKey"
+        spidSamlAssertion:
+          $ref: "#/components/schemas/SamlAssertion"
+        documentSignatures:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentSignature"
+        qtspClauses:
+          $ref: "#/components/schemas/QtspClausesMetadata"
+      required:
+        - id
+        - signatureRequestId
+        - email
+        - publicKey
+        - spidSamlAssertion
+        - documentSignatures
+        - qtspClauses


### PR DESCRIPTION
This PR begins to describe the openapi specification for the user. It introduces a new `Signature` entity that keeps track of all the signatures affixed to the various fields and integration with the QTSP